### PR TITLE
update of depricated init()

### DIFF
--- a/SeeFood-CoreML/ViewController.swift
+++ b/SeeFood-CoreML/ViewController.swift
@@ -27,7 +27,8 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
     func detect(image: CIImage) {
         
         // Load the ML model through its generated class
-        guard let model = try? VNCoreMLModel(for: MLModel(contentsOf: Inceptionv3.urlOfModelInThisBundle)) else {
+        guard let mlModel = try? Inceptionv3(configuration: .init()).model,
+              let model = try? VNCoreMLModel(for: mlModel) else {
             fatalError("can't load ML model")
         }
         

--- a/SeeFood-CoreML/ViewController.swift
+++ b/SeeFood-CoreML/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
     func detect(image: CIImage) {
         
         // Load the ML model through its generated class
-        guard let model = try? VNCoreMLModel(for: Inceptionv3().model) else {
+        guard let model = try? VNCoreMLModel(for: MLModel(contentsOf: Inceptionv3.urlOfModelInThisBundle)) else {
             fatalError("can't load ML model")
         }
         


### PR DESCRIPTION
Hello, 

I am one of your Udemy students on iOS development and followed your Lesson on CoreML.
I encountered an error message that stated that `'init()' is deprecated: Use init(configuration:) instead and handle errors appropriately.`
The new lines of code is getting rid of that particular error, without losing the ability to operate fully offline.

Thanks for the amazing course and best regards, 
Katharina 
